### PR TITLE
Collection pageCount fix

### DIFF
--- a/orb/core/collection.py
+++ b/orb/core/collection.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from projex.lazymodule import lazy_import
 from projex.locks import ReadWriteLock, ReadLocker, WriteLocker
+import math
 
 orb = lazy_import('orb')
 

--- a/orb/core/collection.py
+++ b/orb/core/collection.py
@@ -500,12 +500,10 @@ class Collection(object):
             return 1
         else:
             context['page'] = None
-            context['limit'] = None
+            context['pageSize'] = None
 
             fraction = self.count(**context) / float(size)
-            count = int(fraction)
-            if count % 1:
-                count += 1
+            count = int(math.ceil(fraction))
             return max(1, count)
 
     def preload(self, cache, **context):


### PR DESCRIPTION
When there were more records than pageSize, count was always returning pageSize so pageCount always returned 1. By setting pageSize=None instead of limit=None in the context, count correctly returns the total count of records, and by using math.ceil, the number of pages is always rounded up instead of down (otherwise, it was returning 1 less page than there actually was).

References TBWB-1936