### PR TITLE
* more PEP8 conversions - testFlag => test_flag, idColumn => id_colum…

### DIFF
--- a/orb/core/collector.py
+++ b/orb/core/collector.py
@@ -1,10 +1,14 @@
-import inflection
-import projex.text
+"""
+Defines the base collector class type.  Collectors are defined on
+models and are used to create lookups between records.
+"""
 
-from projex.enum import enum
-from projex.lazymodule import lazy_import
+import demandimport
 
-orb = lazy_import('orb')
+from ..utils.enum import enum
+
+with demandimport.enabled():
+    import orb
 
 
 class Collector(object):
@@ -17,7 +21,51 @@ class Collector(object):
         'AutoExpand'
     )
 
+    def __init__(self,
+                 model=None,
+                 name='',
+                 flags=0,
+                 getter=None,
+                 setter=None,
+                 filter=None,
+                 schema=None):
+        # define custom properties
+        self.__model = model
+        self.__name = self.__name__ = name
+        self.__flags = self.Flags.from_set(flags) if isinstance(flags, set) else flags
+        self.__gettermethod = getter
+        self.__settermethod = setter
+        self.__filtermethod = filter
+        self.__schema = schema
+
+    def __call__(self, source_record, use_method=True, **context):
+        """
+        Executes the logic for collecting the records for this
+        instance.  If there is a specific getter method associated
+        with this collector, and the `use_method` property is True then
+        that function is called.
+
+        :param source_record: <orb.Model>
+        :param use_method: <bool>
+        :param context: <orb.Context>
+
+        :return: <orb.Collection>
+        """
+        return self.collect(source_record, use_method=use_method, **context)
+
+    def __cmp__(self, other):
+        if isinstance(other, Collector):
+            return cmp(self.name(), other.name())
+        else:
+            return -1
+
     def __json__(self):
+        """
+        Serializes this collector object as the descriptor for
+        it's meta data.
+
+        :return: <dict>
+        """
         try:
             model = self.model()
         except orb.errors.ModelNotFound:
@@ -28,171 +76,341 @@ class Collector(object):
         output = {
             'name': self.__name,
             'model': model_name,
-            'flags': {k: True for k in self.Flags.toSet(self.__flags)}
+            'flags': {k: True for k in self.Flags.to_set(self.__flags)}
         }
         return output
 
-    def __init__(self,
-                 name='',
-                 flags=0,
-                 getter=None,
-                 setter=None,
-                 model=None,
-                 queryFilter=None):
-        self.__name = self.__name__ = name
-        self.__model = model
-        self.__schema = None
-        self.__preload = None
-        self.__getter = getter
-        self.__setter = setter
-        self.__query_filter = queryFilter
-        self.__flags = self.Flags.fromSet(flags) if isinstance(flags, set) else flags
+    def _collect(self, source_record, **context):
+        """
+        Protected method used to perform actual data collection from the backend.
+        This method is abstract and will need to be implemented in a sub-class based
+        on the requirements for that collector type.
 
-    def __call__(self, record, use_method=True, **context):
-        if self.__getter and use_method:
-            return self.__getter(record, **context)
+        :param source_record: <orb.Model>
+        :param context: <orb.Context>
+
+        :return: <orb.Collection>
+        """
+        raise NotImplementedError
+
+    def add_record(self, source_record, target_record, **context):
+        """
+        Adds a new record to the backend through this collector.  This method
+        takes the source and target records as input and generates the relationship
+        between them that will be required for future lookup by this collector.
+
+        This is an abstractmethod and needs to be implemented by a sub-class for
+        it to work.
+
+        :param source_record: <orb.Model>
+        :param target_record: <orb.Model>
+        :param context: <orb.Context> descriptor
+
+        :return: <orb.Model> generated relationship
+        """
+        raise NotImplementedError
+
+    def collect(self, source_record, use_method=True, **context):
+        """
+        Collects the records that are related to the given source method through
+        this collector.  If a gettermethod is defined for this collector, and the
+        `use_method` is True, then that gettermethod will be called.  Otherwise
+        the base logic for this collector is called.
+
+        :param source_record: <orb.Model>
+        :param use_method: <bool>
+        :param context: <orb.Context> descriptor
+
+        :return: <orb.Collection>
+        """
+        # run the gettermethod for this collector if specified
+        # and available
+        if self.__gettermethod is not None and use_method:
+            return self.__gettermethod(source_record, **context)
+
         else:
-            if not record.isRecord():
+            # ensure we have a valid record for collection
+            if not (source_record and source_record.is_record()):
                 return orb.Collection()
+
+            # run the collect method to gather the records for this
+            # context
             else:
-                collection = self.collect(record, **context)
+                collection = self._collect(source_record, **context)
 
-                # preload the results
+                # pre-load any data that was pulled from the source record for
+                # this collector and auto-assign it to the resulting collection
                 if isinstance(collection, orb.Collection):
-                    record_cache = record.preloaded_data(self.alias())
-                    collection.add_preloaded_data(record_cache, **context)
+                    record_cache = source_record.preloaded_data(self.name())
+                    if record_cache:
+                        collection._add_preloaded_data({'records': record_cache}, **context)
 
-                    if self.testFlag(self.Flags.Unique):
+                    if self.test_flag(self.Flags.Unique):
                         return collection.first()
                     else:
                         return collection
                 else:
                     return collection
 
-    def alias(self):
-        return inflection.underscore(self.name())
+    def collect_expand(self, query, parts, **context):
+        """
+        Adds the query needed to expand this collector into another
+        sub-query.
 
-    def add_record(self, source_record, target_record, **context):
+        This method is abstract and needs to be re-implemented in a sub-class.
+
+        :param query: <orb.Query>
+        :param parts: [<str> sub-expand, ..]
+        :param context: <orb.Context> descriptor
+
+        :return: <orb.Query>
+        """
         raise NotImplementedError
 
     def create_record(self, source_record, values, **context):
-        raise NotImplementedError
+        """
+        Creates a new record through this collector from the given source record with
+        the given values.  This will generate a new model instance based on this collector's
+        model type.  This method will also automatically create the relationship
+        for the new record instance that is represented via the collector.
 
-    def copy(self):
-        out = type(self)(name=self.__name, flags=self.__flags)
-        out.setSchema(self.schema())
-        return out
+        :param source_record: <orb.Model>
+        :param values: <dict>
+        :param context: <orb.Context> descriptor
 
-    def collect(self, record, **context):
-        if self.__getter:
-            return self.__getter(record, **context)
-        raise NotImplementedError
-
-    def collectExpand(self, query, parts, **context):
+        :return: <orb.Model> generated model
+        """
         raise NotImplementedError
 
     def delete_records(self, collection, **context):
-        return False, 0
-
-    def queryFilter(self, function=None):
         """
-        Defines a decorator that can be used to filter
-        queries.  It will assume the function being associated
-        with the decorator will take a query as an input and
-        return a modified query to use.
+        Deletes the collection of records from the database.  This method
+        is abstract and needs to be re-implemented in a sub-class.
 
-        :usage
+        :param collection: <orb.Collection>
+        :param context: <orb.Context> descriptor
+
+        :return: [<orb.Model>, ..] processed, <int> count deleted
+        """
+        raise NotImplementedError
+
+    def filter(self, function=None):
+        """
+        Decorator for wrapping a function to use as the filter method
+        for this collector.  The filter method will generate queries
+        to allow filtering based on this collector from the backend.
+
+        :usage:
 
             class MyModel(orb.Model):
                 objects = orb.ReverseLookup('Object')
 
                 @classmethod
-                @objects.queryFilter()
-                def objectsFilter(cls, query, **context):
+                @objects.filter()
+                def objects_filter(cls, query, **context):
                     return orb.Query()
 
         :param function: <callable>
 
-        :return: <wrapper>
+        :return: <callable>
         """
         if function is not None:
-            self.__query_filter = function
+            self.__filtermethod = function
             return function
+        else:
+            def wrapper(f):
+                self.__filtermethod = f
+                return f
+            return wrapper
 
-        def wrapper(func):
-            self.__query_filter = func
-            return func
-        return wrapper
-
-    def queryFilterMethod(self):
+    def filtermethod(self):
         """
         Returns the actual query filter method, if any,
         that is associated with this collector.
 
         :return: <callable>
         """
-        return self.__query_filter
+        return self.__filtermethod
 
     def getter(self, function=None):
-        if function is not None:
-            self.__getter = function
-            return function
+        """
+        Decorator for wrapping a function to use as the getter method
+        for this collector.  The getter method will return a collection
+        of records that are associated with this method.  Usage of
+        this system will override the default `collect` method for
+        this collector.
 
-        def wrapper(func):
-            self.__getter = func
-            return func
-        return wrapper
+        :usage:
+
+            class MyModel(orb.Model):
+                objects = orb.ReverseLookup('Object')
+
+                @classmethod
+                @objects.getter()
+                def get_objects(cls, **context):
+                    return orb.Collection()
+
+        :param function: <callable>
+
+        :return: <callable>
+        """
+        if function is not None:
+            self.__gettermethod = function
+            return function
+        else:
+            def wrapper(f):
+                self.__gettermethod = f
+                return f
+            return wrapper
 
     def gettermethod(self):
-        return self.__getter
+        """
+        Returns the getter method associated with this collector.  When
+        defined, the getter method will override the `collect` method used
+        when gathering records for this collector.  This will override the
+        values returned when using the `orb.Model.get` method on a collector.
+
+        :return: <callable> or None
+        """
+        return self.__gettermethod
 
     def flags(self):
+        """
+        Returns the flags that have been set for this collector instance.
+
+        :return: <int> Collector.Flags
+        """
         return self.__flags
 
     def model(self):
+        """
+        Returns the model instance that is associated with this collector.
+        If a string is associated with the model type for this collector,
+        it is possible for this method to raise an `orb.errors.ModelNotFound`
+        error.
+
+        :return: <orb.Model>
+        """
         if isinstance(self.__model, (str, unicode)):
-            schema = orb.system.schema(self.__model)
-            if schema is not None:
-                return schema.model()
-            else:
-                raise orb.errors.ModelNotFound(schema=self.__model)
-        else:
-            return self.__model
+            system = self.__schema.system() if self.__schema else orb.system
+            self.__model = system.model(self.__model)
+        return self.__model
 
     def name(self):
+        """
+        Returns the name of this collector.
+
+        :return: <str>
+        """
         return self.__name
 
     def remove_record(self, source_record, target_record, **context):
+        """
+        Removes the relationship between the source_record and target_record for this
+        collector instance.
+
+        :param source_record: <orb.Model>
+        :param target_record: <orb.Model>
+        :param context: <orb.Context>
+
+        :return: <int> number of records removed
+        """
         raise NotImplementedError
 
+    def set_name(self, name):
+        """
+        Sets the name of this collector to the given string.
+
+        :param name: <str>
+        """
+        self.__name = name
+
     def schema(self):
+        """
+        Returns the schema that is associated with this collector
+        instance.
+
+        :return: <orb.Schema>
+        """
         return self.__schema
 
     def setter(self, function=None):
+        """
+        Decorator for wrapping a function to use as the setter method
+        for this collector.  The setter method will take a collection
+        of records and associate them with this collector instance.  Usage of
+        this system will override the default `orb.Model.set` method for
+        this collector.
+
+        :usage:
+
+            class MyModel(orb.Model):
+                objects = orb.ReverseLookup('Object')
+
+                @classmethod
+                @objects.setter()
+                def set_objects(cls, records, **context):
+                    pass
+
+        :param function: <callable>
+
+        :return: <callable>
+        """
         if function is not None:
-            self.__setter = function
+            self.__settermethod = function
             return function
-
-        def wrapper(func):
-            self.__setter = func
-            return func
-
-        return wrapper
+        else:
+            def wrapper(f):
+                self.__settermethod = f
+                return f
+            return wrapper
 
     def settermethod(self):
-        return self.__setter
+        """
+        Returns the setter method associated with this collector.  This will override
+        the action provided to the `orb.Model.set` method when setting values of a collector.
 
-    def setName(self, name):
-        self.__name = self.__name__ = name
+        :return: <callable> or None
+        """
+        return self.__settermethod
 
-    def setSchema(self, schema):
+    def set_schema(self, schema):
+        """
+        Sets the schema that is associated with this collector
+        instance.
+
+        :param schema: <orb.Schema>
+        """
         self.__schema = schema
 
-    def setFlags(self, flags):
+    def set_flags(self, flags):
+        """
+        Sets the flag values for this collector to the given set of flags.
+
+        :param flags: <int>
+        """
         self.__flags = flags
 
-    def testFlag(self, flag):
+    def test_flag(self, flag):
+        """
+        Checks to see if the given flag is defined for this
+        collector.
+
+        :param flag: <int>
+
+        :return: <bool>
+        """
         return (self.__flags & flag) > 0
 
-    def update_records(self, collection, source_record, record_ids, **context):
+    def update_records(self, source_record, collection, collection_ids, **context):
+        """
+        Updates the source record with the new collection of related records based
+        on this collector's required relationships.  This is an abstract method
+        and needs to be implemented per sub-class.
+
+        :param source_record: <orb.Model>
+        :param collection: <orb.Collection> new related records
+        :param collection_ids: [<variant> id, ..] list of new related ids
+        :param context: <orb.Context> descriptor
+        """
         raise NotImplementedError

--- a/orb/core/column_types/numeric.py
+++ b/orb/core/column_types/numeric.py
@@ -180,7 +180,7 @@ class EnumColumn(LongColumn):
         Returns the enumeration that is associated with this column.  This can
         help for automated validation when dealing with enumeration types.
 
-        :return     <projex.enum.enum> || None
+        :return: <orb.utils.enum.enum> or None
         """
         return self.__enum
 
@@ -190,7 +190,7 @@ class EnumColumn(LongColumn):
         type.  This is an optional parameter but can be useful when dealing
         with validation and some of the automated features of the ORB system.
 
-        :param      cls | <projex.enum.enum> || None
+        :param cls: <orb.utils.enum.enum> or None
         """
         self.__enum = cls
 

--- a/orb/core/column_types/string.py
+++ b/orb/core/column_types/string.py
@@ -117,7 +117,7 @@ class AbstractStringColumn(Column):
 
         :return     <variant>
         """
-        if isinstance(value, (str, unicode)) and self.testFlag(self.Flags.Encrypted):
+        if isinstance(value, (str, unicode)) and self.test_flag(self.Flags.Encrypted):
             value = security.encrypt(value)
 
         return super(AbstractStringColumn, self).store(value, context=context)

--- a/orb/core/connection_types/sql/mysql/statements/add_column.py
+++ b/orb/core/connection_types/sql/mysql/statements/add_column.py
@@ -9,7 +9,7 @@ class ADD_COLUMN(MySQLStatement):
         # determine all the flags for this column
         flags = []
         Flags = orb.Column.Flags
-        for key, value in Flags.items():
+        for key, value in Flags:
             if column.flags() & value:
                 flag_sql = MySQLStatement.byName('Flag::{0}'.format(key))
                 if flag_sql:

--- a/orb/core/connection_types/sql/mysql/statements/alter.py
+++ b/orb/core/connection_types/sql/mysql/statements/alter.py
@@ -30,10 +30,10 @@ class ALTER(MySQLStatement):
         add_standard = []
         for col in add or []:
             # virtual columns do not exist in the database
-            if col.testFlag(col.Flags.Virtual):
+            if col.test_flag(col.Flags.Virtual):
                 continue
 
-            if col.testFlag(col.Flags.I18n):
+            if col.test_flag(col.Flags.I18n):
                 add_i18n.append(col)
             else:
                 add_standard.append(col)
@@ -62,7 +62,7 @@ class ALTER(MySQLStatement):
 
         # add i18n columns
         if add_i18n:
-            id_column = model.schema().idColumn()
+            id_column = model.schema().id_column()
             id_type = id_column.dbType('MySQL')
 
             field_statements = []

--- a/orb/core/connection_types/sql/mysql/statements/create.py
+++ b/orb/core/connection_types/sql/mysql/statements/create.py
@@ -20,10 +20,10 @@ class CREATE(MySQLStatement):
         schema = model.schema()
         data = {}
 
-        id_column = schema.idColumn()
-        base_model = id_column.referenceModel()
+        id_column = schema.id_column()
+        base_model = id_column.reference_model()
         base_schema = base_model.schema()
-        base_id = base_schema.idColumn()
+        base_id = base_schema.id_column()
 
         preload = {}
         columns = []
@@ -43,10 +43,10 @@ class CREATE(MySQLStatement):
                 if not isinstance(column, orb.ReferenceColumn):
                     return '`{0}`.`{1}`'.format(alias, column.field())
                 else:
-                    ref_model = column.referenceModel()
+                    ref_model = column.reference_model()
                     alias = alias or ref_model.schema().dbname()
                     join_alias = alias + '_' + projex.text.underscore(column.name())
-                    target = '`{0}`.`{1}`'.format(join_alias, ref_model.schema().idColumn().field())
+                    target = '`{0}`.`{1}`'.format(join_alias, ref_model.schema().id_column().field())
                     source = '`{0}`.`{1}`'.format(alias, column.field())
                     join = {
                         'namespace': ref_model.schema().namespace() or default_namespace,
@@ -77,7 +77,7 @@ class CREATE(MySQLStatement):
 
                 if isinstance(collector, orb.Pipe):
                     join_schema = collector.toModel().schema()
-                    join_id = join_schema.idColumn()
+                    join_id = join_schema.id_column()
 
                     pipe_schema = collector.throughModel().schema()
                     source_col = collector.fromColumn()
@@ -121,7 +121,7 @@ class CREATE(MySQLStatement):
                                                           join_schema.dbname())
                 else:
                     join_schema = collector.targetModel()
-                    join_id = join_schema.idColumn()
+                    join_id = join_schema.id_column()
                     join_field = '`{0}`'.format(join_id.field())
                     column_name = projex.text.underscore(collector.name())
                     order = join_schema.defaultOrder() or [(join_id.field(), 'asc')]
@@ -178,22 +178,22 @@ class CREATE(MySQLStatement):
         curr_schema = base_model.schema()
         curr_field = '`{0}`.`{1}`'.format(base_model.schema().dbname(), base_id.field())
 
-        columns.append('{0} AS `{1}`'.format(curr_field, schema.idColumn().field()))
+        columns.append('{0} AS `{1}`'.format(curr_field, schema.id_column().field()))
         group_by.append(curr_field)
 
         for column in schema.columns().values():
-            if column == schema.idColumn():
+            if column == schema.id_column():
                 continue
             else:
                 parts = column.shortcut().split('.')
-                if not (len(parts) > 1 and parts[0] == schema.idColumn().name()):
+                if not (len(parts) > 1 and parts[0] == schema.id_column().name()):
                     raise orb.errors.QueryInvalid('All view columns must originate from the id')
 
                 field_name = populate(curr_schema, curr_field, parts[1:], curr_schema.dbname())
                 columns.append('{0} AS `{1}`'.format(field_name, column.field()))
 
         kwds = {
-            'materialized': 'MATERIALIZED' if schema.testFlags(schema.Flags.Static) else '',
+            'materialized': 'MATERIALIZED' if schema.test_flag(schema.Flags.Static) else '',
             'view': schema.dbname(),
             'base_table': base_schema.dbname(),
             'preload': ','.join(['{0} AS {1}'.format(k, v) for k, v in preload.items()]),
@@ -229,10 +229,10 @@ class CREATE(MySQLStatement):
                 continue
 
             # virtual flags do not exist in the database
-            elif col.testFlag(col.Flags.Virtual):
+            elif col.test_flag(col.Flags.Virtual):
                 continue
 
-            if col.testFlag(col.Flags.I18n):
+            if col.test_flag(col.Flags.I18n):
                 add_i18n.append(col)
             else:
                 add_standard.append(col)
@@ -255,9 +255,9 @@ class CREATE(MySQLStatement):
             if not inherits_model:
                 raise orb.errors.ModelNotFound(schema=inherits)
 
-            id_column = inherits_model.schema().idColumn()
+            id_column = inherits_model.schema().id_column()
             id_type = id_column.dbType('MySQL').replace('AUTO_INCREMENT', '').strip()
-            base_id_column = model.schema().idColumn()
+            base_id_column = model.schema().id_column()
 
             inherits = '`{0}` {1} REFERENCES `{2}`\n'.format(base_id_column.field(),
                                                              id_type,
@@ -266,7 +266,7 @@ class CREATE(MySQLStatement):
 
         # get the primary column
         pcol = ''
-        id_column = model.schema().idColumn()
+        id_column = model.schema().id_column()
         if id_column:
             pcol = '`{0}`'.format(id_column.field())
             cmd_body.append('CONSTRAINT `{0}_pkey` PRIMARY KEY ({1})'.format(model.schema().dbname(), pcol))
@@ -283,7 +283,7 @@ class CREATE(MySQLStatement):
 
         # create the i18n model
         if add_i18n:
-            id_column = model.schema().idColumn()
+            id_column = model.schema().id_column()
             id_type = id_column.dbType('MySQL')
 
             field_statements = []

--- a/orb/core/connection_types/sql/mysql/statements/create_index.py
+++ b/orb/core/connection_types/sql/mysql/statements/create_index.py
@@ -17,10 +17,10 @@ class CREATE_INDEX(MySQLStatement):
         """
         schema_name = index.schema().dbname()
         index_name = index.dbname()
-        cmd = 'CREATE' if not index.testFlag(index.Flags.Unique) else 'CREATE UNIQUE'
+        cmd = 'CREATE' if not index.test_flag(index.Flags.Unique) else 'CREATE UNIQUE'
 
         cols = ['`{0}`'.format(col.field())
-                if isinstance(col, orb.AbstractStringColumn) and not col.testFlag(col.Flags.CaseSensitive)
+                if isinstance(col, orb.AbstractStringColumn) and not col.test_flag(col.Flags.CaseSensitive)
                 else '`{0}`'.format(col.field())
                 for col in index.columns()]
 

--- a/orb/core/connection_types/sql/mysql/statements/delete.py
+++ b/orb/core/connection_types/sql/mysql/statements/delete.py
@@ -21,7 +21,7 @@ class DELETE(MySQLStatement):
             sql_options = {
                 'namespace': model.schema().namespace() or context.db.name(),
                 'table': model.schema().dbname(),
-                'id_col': model.schema().idColumn().field(),
+                'id_col': model.schema().id_column().field(),
                 'where': 'WHERE {0}'.format(where) if where else ''
             }
             sql = (
@@ -47,7 +47,7 @@ class DELETE(MySQLStatement):
             delete_info = defaultdict(list)
             for record in records:
                 schema = record.schema()
-                delete_info[schema].append(record.get(record.schema().idColumn()))
+                delete_info[schema].append(record.get(record.schema().id_column()))
 
             data = {}
             sql = []
@@ -56,7 +56,7 @@ class DELETE(MySQLStatement):
                 schema_sql = u'DELETE FROM `{0}`.`{1}` WHERE {2} IN %({1}_ids)s;'
                 schema_sql = schema_sql.format(schema.namespace() or default_namespace,
                                                schema.dbname(),
-                                               schema.idColumn().field())
+                                               schema.id_column().field())
                 if schema.columns(flags=orb.Column.Flags.I18n):
                     i18n_sql = u'DELETE FROM `{0}`.`{1}_i18n` WHERE `{1}_id` IN %({1}_ids)s;'.format(schema.namespace(),
                                                                                                      schema.dbname())

--- a/orb/core/connection_types/sql/mysql/statements/insert.py
+++ b/orb/core/connection_types/sql/mysql/statements/insert.py
@@ -17,16 +17,16 @@ class INSERT(MySQLStatement):
         schema_records = defaultdict(lambda: defaultdict(list))
         for i, record in enumerate(records):
             schema = record.schema()
-            id_column = schema.idColumn()
+            id_column = schema.id_column()
 
             # define the
             if not schema in schema_meta:
                 i18n = []
                 standard = []
                 for col in schema.columns().values():
-                    if col.testFlag(col.Flags.Virtual):
+                    if col.test_flag(col.Flags.Virtual):
                         continue
-                    if col.testFlag(col.Flags.I18n):
+                    if col.test_flag(col.Flags.I18n):
                         i18n.append(col)
                     else:
                         standard.append(col)
@@ -40,7 +40,7 @@ class INSERT(MySQLStatement):
                 record_values = {}
                 for col in columns:
                     value = col.dbStore('MySQL', record.get(col))
-                    if col == id_column and not id_column.testFlag(id_column.Flags.AutoAssign) and record.id() is None:
+                    if col == id_column and not id_column.test_flag(id_column.Flags.AutoAssign) and record.id() is None:
                         record.set(col, value)
                     record_values['{0}_{1}'.format(col.field(), i)] = value
 
@@ -58,7 +58,7 @@ class INSERT(MySQLStatement):
 
         cmd = []
         for schema, columns in schema_meta.items():
-            id_column = schema.idColumn()
+            id_column = schema.id_column()
             subcmd = ''
             if columns['standard']:
                 cols = ', '.join(['`{0}`'.format(col.field()) for col in columns['standard']])
@@ -102,7 +102,7 @@ class INSERT(MySQLStatement):
 
             cmd.append(subcmd)
 
-            if schema.idColumn().testFlag(orb.Column.Flags.AutoAssign):
+            if schema.id_column().test_flag(orb.Column.Flags.AutoAssign):
                 cmd.append('SELECT * FROM `{1}`.`{2}` WHERE `{0}` >= LAST_INSERT_ID();'.format(
                     id_column.field(),
                     id_column.schema().namespace() or default_namespace,

--- a/orb/core/connection_types/sql/mysql/statements/select.py
+++ b/orb/core/connection_types/sql/mysql/statements/select.py
@@ -34,19 +34,19 @@ class SELECT(MySQLStatement):
 
         # process columns to select
         for column in sorted(columns, self.cmpcol):
-            if column.testFlag(column.Flags.Virtual):
+            if column.test_flag(column.Flags.Virtual):
                 continue
 
-            if column.testFlag(column.Flags.I18n):
+            if column.test_flag(column.Flags.I18n):
                 if context.locale == 'all':
                     sql = u'hstore_agg(hstore(`i18n`.`locale`, `i18n`.`{0}`)) AS `{0}`'
-                elif data['locale'] == data['default_locale'] or column.testFlag(column.Flags.I18n_NoDefault):
+                elif data['locale'] == data['default_locale'] or column.test_flag(column.Flags.I18n_NoDefault):
                     sql = u'group_concat(`i18n`.`{0}`) AS `{0}`'
                 else:
                     sql = u'(coalesce(group_concat(`i18n`.`{0}`), group_concat(`i18n_default`.`{0}`))) AS `{0}`'
 
                 sql_columns['i18n'].append(sql.format(column.field()))
-                sql_group_by.add(u'`{0}`.`{1}`'.format(schema.dbname(), schema.idColumn().field()))
+                sql_group_by.add(u'`{0}`.`{1}`'.format(schema.dbname(), schema.id_column().field()))
                 fields[column] = u'`i18n`.`{0}`'.format(column.field())
             else:
                 # select the base record
@@ -75,10 +75,10 @@ class SELECT(MySQLStatement):
             inherited_sources = []
             curr_schema = schema
 
-            for ischema in schema.inheritanceTree():
+            for ischema in schema.ancestry():
                 isql = 'LEFT JOIN `{0}`.`{1}` ON `{1}`.`{2}` = `{3}`.`{2}`'.format(ischema.namespace() or context.db.name(),
                                                                                    ischema.dbname(),
-                                                                                   ischema.idColumn().field(),
+                                                                                   ischema.id_column().field(),
                                                                                    curr_schema.dbname())
                 inherited_sources.append(isql)
                 curr_schema = ischema

--- a/orb/core/connection_types/sql/mysql/statements/select_count.py
+++ b/orb/core/connection_types/sql/mysql/statements/select_count.py
@@ -7,7 +7,7 @@ orb = lazy_import('orb')
 class SELECT_COUNT(MySQLStatement):
     def __call__(self, model, context):
         SELECT = self.byName('SELECT')
-        columns = context.columns or [model.schema().idColumn().field()]
+        columns = context.columns or [model.schema().id_column().field()]
         sql, data = SELECT(model, orb.Context(columns=columns, context=context))
         if sql:
             sql = 'SELECT COUNT(*) AS count FROM ({0}) AS records;'.format(sql)

--- a/orb/core/connection_types/sql/mysql/statements/update.py
+++ b/orb/core/connection_types/sql/mysql/statements/update.py
@@ -12,7 +12,7 @@ class UPDATE(MySQLStatement):
         data = {}
 
         for record in records:
-            if record.isRecord():
+            if record.is_record():
                 changes = record.changes()
                 if changes:
                     sub_sql, sub_data = self.generateCommand(record, changes)
@@ -30,10 +30,10 @@ class UPDATE(MySQLStatement):
         i18n_keys = defaultdict(list)
 
         for column in changes:
-            if column.testFlag(column.Flags.Virtual):
+            if column.test_flag(column.Flags.Virtual):
                 continue
 
-            if column.testFlag(column.Flags.I18n):
+            if column.test_flag(column.Flags.I18n):
                 for record_locale, value in record.get(column, locale='all').items():
                     value_key = '{0}_{1}'.format(column.field(), os.urandom(4).encode('hex'))
                     data[value_key] = column.dbStore('MySQL', value)
@@ -47,7 +47,7 @@ class UPDATE(MySQLStatement):
 
 
         id_key = 'id_' + os.urandom(4).encode('hex')
-        data[id_key] = record.get(record.schema().idColumn())
+        data[id_key] = record.get(record.schema().id_column())
         context = record.context()
 
         sql = []
@@ -60,7 +60,7 @@ class UPDATE(MySQLStatement):
                      namespace=record.schema().namespace() or context.db.name(),
                      id=id_key,
                      values=', '.join(standard_values),
-                     field=record.schema().idColumn().field())
+                     field=record.schema().id_column().field())
             sql.append(standard_sql)
 
         if i18n_fields:

--- a/orb/core/connection_types/sql/mysql/statements/where.py
+++ b/orb/core/connection_types/sql/mysql/statements/where.py
@@ -53,7 +53,7 @@ class WHERE(MySQLStatement):
 
             def convert_value(val):
                 if isinstance(val, orb.Model):
-                    return val.get(val.schema().idColumn(), inflated=False)
+                    return val.get(val.schema().id_column(), inflated=False)
                 elif isinstance(val, (tuple, list, set)):
                     return tuple(convert_value(v) for v in val)
                 else:
@@ -109,7 +109,7 @@ class WHERE(MySQLStatement):
                 sql = u' '.join(opts)
                 data[value_key] = value
 
-                if column.testFlag(column.Flags.I18n) and column not in fields:
+                if column.test_flag(column.Flags.I18n) and column not in fields:
                     model_name = aliases.get(model) or model.schema().dbname()
                     i18n_sql = u'`{name}`.`{field}` IN (' \
                           u'    SELECT `{name}_id`' \
@@ -122,7 +122,7 @@ class WHERE(MySQLStatement):
                     sql = i18n_sql.format(name=model_name,
                                           namespace=model.schema().namespace() or default_namespace,
                                           sub_sql=sub_sql,
-                                          field=model.schema().idColumn().field())
+                                          field=model.schema().id_column().field())
 
         return sql, data
 

--- a/orb/core/connection_types/sql/postgres/statements/add_column.py
+++ b/orb/core/connection_types/sql/postgres/statements/add_column.py
@@ -9,7 +9,7 @@ class ADD_COLUMN(PSQLStatement):
         # determine all the flags for this column
         flags = []
         Flags = orb.Column.Flags
-        for key, value in Flags.items():
+        for key, value in Flags:
             if column.flags() & value:
                 flag_sql = PSQLStatement.byName('Flag::{0}'.format(key))
                 if flag_sql:

--- a/orb/core/connection_types/sql/postgres/statements/alter.py
+++ b/orb/core/connection_types/sql/postgres/statements/alter.py
@@ -29,10 +29,10 @@ class ALTER(PSQLStatement):
         add_standard = []
         for col in add or []:
             # virtual columns do not exist in the database
-            if col.testFlag(col.Flags.Virtual):
+            if col.test_flag(col.Flags.Virtual):
                 continue
 
-            if col.testFlag(col.Flags.I18n):
+            if col.test_flag(col.Flags.I18n):
                 add_i18n.append(col)
             else:
                 add_standard.append(col)
@@ -61,7 +61,7 @@ class ALTER(PSQLStatement):
 
         # add i18n columns
         if add_i18n:
-            id_column = model.schema().idColumn()
+            id_column = model.schema().id_column()
             id_type = id_column.dbType('Postgres')
 
             field_statements = []

--- a/orb/core/connection_types/sql/postgres/statements/create_index.py
+++ b/orb/core/connection_types/sql/postgres/statements/create_index.py
@@ -17,10 +17,10 @@ class CREATE_INDEX(PSQLStatement):
         """
         schema_name = index.schema().dbname()
         index_name = index.dbname()
-        cmd = 'CREATE' if not index.testFlag(index.Flags.Unique) else 'CREATE UNIQUE'
+        cmd = 'CREATE' if not index.test_flag(index.Flags.Unique) else 'CREATE UNIQUE'
 
         cols = ['lower("{0}"::varchar)'.format(col.field())
-                if isinstance(col, orb.AbstractStringColumn) and not col.testFlag(col.Flags.CaseSensitive)
+                if isinstance(col, orb.AbstractStringColumn) and not col.test_flag(col.Flags.CaseSensitive)
                 else '"{0}"'.format(col.field())
                 for col in index.columns()]
 

--- a/orb/core/connection_types/sql/postgres/statements/delete.py
+++ b/orb/core/connection_types/sql/postgres/statements/delete.py
@@ -21,7 +21,7 @@ class DELETE(PSQLStatement):
             sql_options = {
                 'namespace': model.schema().namespace() or 'public',
                 'table': model.schema().dbname(),
-                'id_col': model.schema().idColumn().field(),
+                'id_col': model.schema().id_column().field(),
                 'where': 'WHERE {0}'.format(where) if where else ''
             }
             sql = (
@@ -48,7 +48,7 @@ class DELETE(PSQLStatement):
             delete_info = defaultdict(list)
             for record in records:
                 schema = record.schema()
-                delete_info[schema].append(record.get(record.schema().idColumn()))
+                delete_info[schema].append(record.get(record.schema().id_column()))
 
             data = {}
             sql = []
@@ -56,7 +56,7 @@ class DELETE(PSQLStatement):
                 schema_sql = u'DELETE FROM "{0}"."{1}" WHERE {2} IN %({1}_ids)s RETURNING *;'
                 schema_sql = schema_sql.format(schema.namespace() or 'public',
                                                schema.dbname(),
-                                               schema.idColumn().field())
+                                               schema.id_column().field())
                 if schema.columns(flags=orb.Column.Flags.I18n):
                     i18n_sql = u'DELETE FROM "{0}"."{1}_i18n" WHERE "{1}_id" IN %({1}_ids)s;'
                     i18n_sql = i18n_sql.format(schema.namespace() or 'public',

--- a/orb/core/connection_types/sql/postgres/statements/insert.py
+++ b/orb/core/connection_types/sql/postgres/statements/insert.py
@@ -22,9 +22,9 @@ class INSERT(PSQLStatement):
                 i18n = []
                 standard = []
                 for col in schema.columns().values():
-                    if col.testFlag(col.Flags.Virtual):
+                    if col.test_flag(col.Flags.Virtual):
                         continue
-                    if col.testFlag(col.Flags.I18n):
+                    if col.test_flag(col.Flags.I18n):
                         i18n.append(col)
                     else:
                         standard.append(col)
@@ -54,7 +54,7 @@ class INSERT(PSQLStatement):
 
         cmd = []
         for schema, columns in schema_meta.items():
-            id_column = schema.idColumn()
+            id_column = schema.id_column()
             subcmd = ''
             if columns['standard']:
                 cols = ', '.join(['"{0}"'.format(col.field()) for col in columns['standard']])

--- a/orb/core/connection_types/sql/postgres/statements/select.py
+++ b/orb/core/connection_types/sql/postgres/statements/select.py
@@ -60,19 +60,19 @@ class SELECT(PSQLStatement):
 
         # process columns to select
         for column in sorted(columns, self.cmpcol):
-            if column.testFlag(column.Flags.Virtual) and not issubclass(model, orb.View):
+            if column.test_flag(column.Flags.Virtual) and not issubclass(model, orb.View):
                 continue
 
-            elif column.testFlag(column.Flags.I18n):
+            elif column.test_flag(column.Flags.I18n):
                 if context.locale == 'all':
                     sql = u'hstore_agg(hstore("i18n"."locale", "i18n"."{0}")) AS "{0}"'
-                elif data['locale'] == data['default_locale'] or column.testFlag(column.Flags.I18n_NoDefault):
+                elif data['locale'] == data['default_locale'] or column.test_flag(column.Flags.I18n_NoDefault):
                     sql = u'(array_agg("i18n"."{0}"))[1] AS "{0}"'
                 else:
                     sql = u'(coalesce((array_agg("i18n"."{0}"))[1], (array_agg("i18n_default"."{0}"))[1])) AS "{0}"'
 
                 sql_columns['i18n'].append(sql.format(column.field()))
-                sql_group_by.add(u'"{0}"."{1}"'.format(schema.dbname(), schema.idColumn().field()))
+                sql_group_by.add(u'"{0}"."{1}"'.format(schema.dbname(), schema.id_column().field()))
                 fields[column] = u'"i18n"."{0}"'.format(column.field())
 
             else:
@@ -93,7 +93,7 @@ class SELECT(PSQLStatement):
         if expand and not context.columns:
             for collector in schema.collectors().values():
                 if collector.name() in expand:
-                    if collector.testFlag(collector.Flags.Virtual):
+                    if collector.test_flag(collector.Flags.Virtual):
                         continue
 
                     sub_tree = expand.pop(collector.name(), None)
@@ -184,8 +184,8 @@ class SELECT(PSQLStatement):
                 else:
                     distinct = ''
 
-                cmd.append(u'WHERE "{0}"."{1}" IN ('.format(schema.dbname(), schema.idColumn().field()))
-                cmd.append(u'    SELECT DISTINCT {0} "{1}"."{2}"'.format(distinct, schema.dbname(), schema.idColumn().field()))
+                cmd.append(u'WHERE "{0}"."{1}" IN ('.format(schema.dbname(), schema.id_column().field()))
+                cmd.append(u'    SELECT DISTINCT {0} "{1}"."{2}"'.format(distinct, schema.dbname(), schema.id_column().field()))
                 cmd.append(u'    FROM "{0}"."{1}"\n'.format(schema.namespace() or 'public', schema.dbname()))
 
                 if sql_columns['i18n']:

--- a/orb/core/connection_types/sql/postgres/statements/select_count.py
+++ b/orb/core/connection_types/sql/postgres/statements/select_count.py
@@ -7,7 +7,7 @@ orb = lazy_import('orb')
 class SELECT_COUNT(PSQLStatement):
     def __call__(self, model, context):
         SELECT = self.byName('SELECT')
-        columns = context.columns or [model.schema().idColumn().field()]
+        columns = context.columns or [model.schema().id_column().field()]
         sql, data = SELECT(model, orb.Context(columns=columns, context=context))
         if sql:
             sql = 'SELECT COUNT(*) AS count FROM ({0}) AS records;'.format(sql)

--- a/orb/core/connection_types/sql/postgres/statements/select_expand.py
+++ b/orb/core/connection_types/sql/postgres/statements/select_expand.py
@@ -29,12 +29,12 @@ class SELECT_EXPAND(PSQLStatement):
             else:
                 column = schema.column(name, raise_=False)
                 if column:
-                    if not column.testFlag(column.Flags.Virtual) or issubclass(model, orb.View):
+                    if not column.test_flag(column.Flags.Virtual) or issubclass(model, orb.View):
                         yield expand_col, column, sub_tree
                 else:
                     collector = schema.collector(name)
                     if collector:
-                        if not collector.testFlag(collector.Flags.Virtual):
+                        if not collector.test_flag(collector.Flags.Virtual):
                             if isinstance(collector, orb.Pipe):
                                 yield expand_pipe, collector, sub_tree
                             elif isinstance(collector, orb.ReverseLookup):
@@ -60,11 +60,11 @@ class SELECT_EXPAND(PSQLStatement):
 class SELECT_EXPAND_COLUMN(SELECT_EXPAND):
     def __call__(self, column, tree, alias='', context=None):
         data = {}
-        target = column.referenceModel()
+        target = column.reference_model()
         translation_columns = target.schema().columns(flags=orb.Column.Flags.I18n).values()
         target_name = projex.text.underscore(column.name())
         target_alias = '{0}_table'.format(target_name)
-        target_id_field = target.schema().idColumn().field()
+        target_id_field = target.schema().id_column().field()
 
         # get the base table query
         target_q = target.baseQuery(context=context)
@@ -94,7 +94,7 @@ class SELECT_EXPAND_COLUMN(SELECT_EXPAND):
                 for c in translation_columns
             ]
             target_data = ','.join(target_data_options)
-            target_id_field = target.schema().idColumn().field()
+            target_id_field = target.schema().id_column().field()
 
             target_i18n_grouping = u"""
             GROUP BY "{target_alias}"."{target_id_field}"
@@ -158,13 +158,13 @@ class SELECT_EXPAND_COLUMN(SELECT_EXPAND):
 class SELECT_EXPAND_REVERSE(SELECT_EXPAND):
     def __call__(self, reversed, tree, alias='', context=None):
         data = {}
-        target = reversed.referenceModel()
+        target = reversed.reference_model()
         source = reversed.schema().model()
 
         target_name = projex.text.underscore(reversed.name())
         target_records_alias = '{0}_records'.format(target_name)
         target_alias = '{0}_table'.format(target_name)
-        has_translations = target.schema().hasTranslations()
+        has_translations = target.schema().has_translations()
         target_fields = []
 
         # get the base table query
@@ -182,7 +182,7 @@ class SELECT_EXPAND_REVERSE(SELECT_EXPAND):
 
         # collect keywords
         if 'ids' in tree:
-            target_fields.append(u'array_agg({0}.{1}) AS ids'.format(target_records_alias, target.schema().idColumn().field()))
+            target_fields.append(u'array_agg({0}.{1}) AS ids'.format(target_records_alias, target.schema().id_column().field()))
         if 'count' in tree:
             target_fields.append(u'count({0}.*) AS count'.format(target_records_alias))
         if 'first' in tree:
@@ -217,13 +217,13 @@ class SELECT_EXPAND_REVERSE(SELECT_EXPAND):
             'target_fields': u', '.join(target_fields),
             'target_table': target.schema().dbname(),
             'target_namespace': target.schema().namespace() or 'public',
-            'target_id_field': target.schema().idColumn().field(),
+            'target_id_field': target.schema().id_column().field(),
             'target_expand': target_expand,
             'target_records_alias': target_records_alias,
             'source_table': alias or source.schema().dbname(),
             'source_field': reversed.targetColumn().field(),
-            'source_id_field': source.schema().idColumn().field(),
-            'limit_if_unique': 'LIMIT 1' if reversed.testFlag(reversed.Flags.Unique) else ''
+            'source_id_field': source.schema().id_column().field(),
+            'limit_if_unique': 'LIMIT 1' if reversed.test_flag(reversed.Flags.Unique) else ''
         }
 
         # define the sql
@@ -263,7 +263,7 @@ class SELECT_EXPAND_PIPE(SELECT_EXPAND):
 
         # collect keywords
         if 'ids' in tree:
-            target_fields.append(u'array_agg({0}.{1}) AS ids'.format(target_records_alias, target.schema().idColumn().field()))
+            target_fields.append(u'array_agg({0}.{1}) AS ids'.format(target_records_alias, target.schema().id_column().field()))
         if 'count' in tree:
             target_fields.append(u'count({0}.*) AS count'.format(target_records_alias))
         if 'first' in tree:
@@ -276,7 +276,7 @@ class SELECT_EXPAND_PIPE(SELECT_EXPAND):
         # define the sql options
         target_name = projex.text.underscore(pipe.name())
         target_alias = '{0}_table'.format(target_name)
-        has_translations = target.schema().hasTranslations()
+        has_translations = target.schema().has_translations()
 
         # include the base table's filter, if one exists
         target_q = target.baseQuery(context=context)
@@ -298,7 +298,7 @@ class SELECT_EXPAND_PIPE(SELECT_EXPAND):
             target_i18n = target_i18n.format(target_alias=target_alias,
                                              namespace=target.schema().namespace() or 'public',
                                              table=target.schema().dbname(),
-                                             target_id_field=target.schema().idColumn().field())
+                                             target_id_field=target.schema().id_column().field())
         else:
             target_data = u'"{target_alias}".*'.format(target_alias=target_alias)
             target_i18n = ''
@@ -319,13 +319,13 @@ class SELECT_EXPAND_PIPE(SELECT_EXPAND):
             'target_i18n': target_i18n,
             'through_table': through.schema().dbname(),
             'through_namespace': through.schema().namespace() or 'public',
-            'target_id_field': target.schema().idColumn().field(),
+            'target_id_field': target.schema().id_column().field(),
             'target_field': target_col.field(),
             'target_records_alias': target_records_alias,
             'source_table': alias or source.schema().dbname(),
-            'source_id_field': source.schema().idColumn().field(),
+            'source_id_field': source.schema().id_column().field(),
             'source_field': source_col.field(),
-            'limit_if_unique': 'LIMIT 1' if pipe.testFlag(pipe.Flags.Unique) else ''
+            'limit_if_unique': 'LIMIT 1' if pipe.test_flag(pipe.Flags.Unique) else ''
         }
 
         # define the sql

--- a/orb/core/connection_types/sql/postgres/statements/update.py
+++ b/orb/core/connection_types/sql/postgres/statements/update.py
@@ -12,7 +12,7 @@ class UPDATE(PSQLStatement):
         data = {}
 
         for record in records:
-            if record.isRecord():
+            if record.is_record():
                 changes = record.changes()
                 if changes:
                     sub_sql, sub_data = self.generateCommand(record, changes)
@@ -30,10 +30,10 @@ class UPDATE(PSQLStatement):
         i18n_keys = defaultdict(list)
 
         for column in changes:
-            if column.testFlag(column.Flags.Virtual):
+            if column.test_flag(column.Flags.Virtual):
                 continue
 
-            if column.testFlag(column.Flags.I18n):
+            if column.test_flag(column.Flags.I18n):
                 for record_locale, value in record.get(column, locale='all').items():
                     value_key = '{0}_{1}'.format(column.field(), os.urandom(4).encode('hex'))
                     data[value_key] = column.dbStore('Postgres', value)
@@ -47,7 +47,7 @@ class UPDATE(PSQLStatement):
 
 
         id_key = 'id_' + os.urandom(4).encode('hex')
-        data[id_key] = record.get(record.schema().idColumn())
+        data[id_key] = record.get(record.schema().id_column())
 
         sql = []
         if standard_values:
@@ -59,7 +59,7 @@ class UPDATE(PSQLStatement):
                      namespace=record.schema().namespace() or 'public',
                      id=id_key,
                      values=', '.join(standard_values),
-                     field=record.schema().idColumn().field())
+                     field=record.schema().id_column().field())
             sql.append(standard_sql)
 
         if i18n_fields:

--- a/orb/core/connection_types/sql/postgres/statements/where.py
+++ b/orb/core/connection_types/sql/postgres/statements/where.py
@@ -50,7 +50,7 @@ class WHERE(PSQLStatement):
 
                 # determine if the collector has a filter
                 if collector:
-                    query_filter = collector.queryFilterMethod()
+                    query_filter = collector.filtermethod()
                     if query_filter:
                         new_query = query_filter(model, query)
                         return self(model, new_query, context, aliases=aliases, fields=fields)
@@ -80,7 +80,7 @@ class WHERE(PSQLStatement):
 
             def convert_value(val):
                 if isinstance(val, orb.Model):
-                    return val.get(val.schema().idColumn(), inflated=False)
+                    return val.get(val.schema().id_column(), inflated=False)
                 elif isinstance(val, (tuple, list, set)):
                     return tuple(convert_value(v) for v in val)
                 else:
@@ -112,7 +112,7 @@ class WHERE(PSQLStatement):
                 SELECT = self.byName('SELECT')
                 context = value.context()
                 if not context.columns:
-                    context.columns = [value.model().schema().idColumn()]
+                    context.columns = [value.model().schema().id_column()]
                     context.distinct = True
 
                 sub_sql, sub_data = SELECT(value.model(), context, fields=fields)
@@ -149,7 +149,7 @@ class WHERE(PSQLStatement):
                 sql = u' '.join(opts)
                 data[value_key] = value
 
-                if column.testFlag(column.Flags.I18n) and column not in fields:
+                if column.test_flag(column.Flags.I18n) and column not in fields:
                     model_name = aliases.get(model) or model.schema().dbname()
                     i18n_sql = u'"{name}"."{field}" IN (' \
                           u'    SELECT "{name}_id"' \
@@ -165,7 +165,7 @@ class WHERE(PSQLStatement):
                     sql = i18n_sql.format(name=model_name,
                                           namespace=model.schema().namespace() or 'public',
                                           sub_sql=sub_sql,
-                                          field=model.schema().idColumn().field())
+                                          field=model.schema().id_column().field())
 
         return sql, data
 

--- a/orb/core/connection_types/sql/sqlite/statements/add_column.py
+++ b/orb/core/connection_types/sql/sqlite/statements/add_column.py
@@ -9,7 +9,7 @@ class ADD_COLUMN(SQLiteStatement):
         # determine all the flags for this column
         flags = []
         Flags = orb.Column.Flags
-        for key, value in Flags.items():
+        for key, value in Flags:
             # SQLite has an issue with adding NOT NULL constraints during an ADD COLUMN during
             # modification of an existing table
             if value == Flags.Required:

--- a/orb/core/connection_types/sql/sqlite/statements/alter.py
+++ b/orb/core/connection_types/sql/sqlite/statements/alter.py
@@ -27,10 +27,10 @@ class ALTER(SQLiteStatement):
         add_i18n = []
         add_standard = []
         for col in add or []:
-            if col.testFlag(col.Flags.Virtual):
+            if col.test_flag(col.Flags.Virtual):
                 continue
 
-            if col.testFlag(col.Flags.I18n):
+            if col.test_flag(col.Flags.I18n):
                 add_i18n.append(col)
             else:
                 add_standard.append(col)
@@ -50,7 +50,7 @@ class ALTER(SQLiteStatement):
 
         # add i18n columns
         if add_i18n:
-            id_column = model.schema().idColumn()
+            id_column = model.schema().id_column()
             id_type = id_column.dbType('SQLite')
 
             i18n_options = {

--- a/orb/core/connection_types/sql/sqlite/statements/create.py
+++ b/orb/core/connection_types/sql/sqlite/statements/create.py
@@ -21,13 +21,13 @@ class CREATE(SQLiteStatement):
 
         # divide columns between standard and translatable
         for col in model.schema().columns(recurse=False).values():
-            if col.testFlag(col.Flags.Virtual):
+            if col.test_flag(col.Flags.Virtual):
                 continue
 
             if not includeReferences and isinstance(col, orb.ReferenceColumn):
                 continue
 
-            if col.testFlag(col.Flags.I18n):
+            if col.test_flag(col.Flags.I18n):
                 add_i18n.append(col)
             else:
                 add_standard.append(col)
@@ -46,7 +46,7 @@ class CREATE(SQLiteStatement):
             cmd_body.append('__base_id INTEGER')
 
         # get the primary column
-        id_column = model.schema().idColumn()
+        id_column = model.schema().id_column()
         if id_column and not inherits:
             pcol = '`{0}`'.format(id_column.field())
             cmd_body.append('CONSTRAINT `{0}_pkey` PRIMARY KEY ({1})'.format(model.schema().dbname(), pcol))
@@ -60,7 +60,7 @@ class CREATE(SQLiteStatement):
 
         # create the i18n model
         if add_i18n:
-            id_column = model.schema().idColumn()
+            id_column = model.schema().id_column()
             id_type = id_column.dbType('SQLite')
 
             i18n_body = ',\n\t'.join([ADD_COLUMN(col)[0].replace('ADD COLUMN ', '') for col in add_i18n])

--- a/orb/core/connection_types/sql/sqlite/statements/create_index.py
+++ b/orb/core/connection_types/sql/sqlite/statements/create_index.py
@@ -17,9 +17,9 @@ class CREATE_INDEX(SQLiteStatement):
         """
         schema_name = index.schema().dbname()
         index_name = index.dbname()
-        cmd = 'CREATE' if not index.testFlag(index.Flags.Unique) else 'CREATE UNIQUE'
+        cmd = 'CREATE' if not index.test_flag(index.Flags.Unique) else 'CREATE UNIQUE'
 
-        cols = ['`{0}`'.format(col.field()) if col.testFlag(col.Flags.CaseSensitive)
+        cols = ['`{0}`'.format(col.field()) if col.test_flag(col.Flags.CaseSensitive)
                 else '`{0}` COLLATE NOCASE'.format(col.field())
                 for col in index.columns()]
 

--- a/orb/core/connection_types/sql/sqlite/statements/delete.py
+++ b/orb/core/connection_types/sql/sqlite/statements/delete.py
@@ -35,12 +35,12 @@ class DELETE(SQLiteStatement):
             delete_info = defaultdict(list)
             for record in records:
                 schema = record.schema()
-                delete_info[schema].append(record.get(record.schema().idColumn()))
+                delete_info[schema].append(record.get(record.schema().id_column()))
 
             data = {}
             sql = []
             for schema, ids in delete_info.items():
-                sql.append(u'DELETE FROM `{0}` WHERE {1} IN %({0}_ids)s;'.format(schema.dbname(), schema.idColumn().field()))
+                sql.append(u'DELETE FROM `{0}` WHERE {1} IN %({0}_ids)s;'.format(schema.dbname(), schema.id_column().field()))
                 data[schema.dbname() + '_ids'] = tuple(ids)
 
             return u'\n'.join(sql), data

--- a/orb/core/connection_types/sql/sqlite/statements/insert.py
+++ b/orb/core/connection_types/sql/sqlite/statements/insert.py
@@ -22,12 +22,12 @@ class INSERT(SQLiteStatement):
                 i18n = []
                 standard = []
                 for col in schema.columns().values():
-                    if col.testFlag(col.Flags.Virtual):
+                    if col.test_flag(col.Flags.Virtual):
                         continue
 
-                    if col.testFlag(col.Flags.I18n):
+                    if col.test_flag(col.Flags.I18n):
                         i18n.append(col)
-                    elif not col.testFlag(col.Flags.AutoAssign):
+                    elif not col.test_flag(col.Flags.AutoAssign):
                         standard.append(col)
 
                 schema_meta[schema] = {'i18n': i18n, 'standard': standard}
@@ -42,7 +42,7 @@ class INSERT(SQLiteStatement):
 
         cmd = []
         for schema, columns in schema_meta.items():
-            id_column = schema.idColumn()
+            id_column = schema.id_column()
             subcmd = ''
 
             if columns['standard']:

--- a/orb/core/connection_types/sql/sqlite/statements/select.py
+++ b/orb/core/connection_types/sql/sqlite/statements/select.py
@@ -34,13 +34,13 @@ class SELECT(SQLiteStatement):
 
         # process columns to select
         for column in sorted(columns, self.cmpcol):
-            if column.testFlag(column.Flags.Virtual) and not issubclass(model, orb.View):
+            if column.test_flag(column.Flags.Virtual) and not issubclass(model, orb.View):
                 continue
 
-            if column.testFlag(column.Flags.I18n):
+            if column.test_flag(column.Flags.I18n):
                 if context.locale == 'all':
                     sql = u'hstore_agg(hstore(`i18n`.`locale`, `i18n`.`{0}`)) AS `{0}`'
-                elif data['locale'] == data['default_locale'] or column.testFlag(column.Flags.I18n_NoDefault):
+                elif data['locale'] == data['default_locale'] or column.test_flag(column.Flags.I18n_NoDefault):
                     sql = u'(array_agg(`i18n`.`{0}`))[1] AS `{0}`'
                 else:
                     sql = u'(coalesce((array_agg(`i18n`.`{0}`))[1], (array_agg(`i18n_default`.`{0}`))[1])) AS `{0}`'

--- a/orb/core/connection_types/sql/sqlite/statements/select_count.py
+++ b/orb/core/connection_types/sql/sqlite/statements/select_count.py
@@ -7,7 +7,7 @@ orb = lazy_import('orb')
 class SELECT_COUNT(SQLiteStatement):
     def __call__(self, model, context):
         SELECT = self.byName('SELECT')
-        columns = context.columns or [model.schema().idColumn().field()]
+        columns = context.columns or [model.schema().id_column().field()]
         sql, data = SELECT(model, orb.Context(columns=columns, context=context))
         if sql:
             sql = 'SELECT COUNT(*) AS count FROM ({0}) AS records;'.format(sql)

--- a/orb/core/connection_types/sql/sqlite/statements/update.py
+++ b/orb/core/connection_types/sql/sqlite/statements/update.py
@@ -12,7 +12,7 @@ class UPDATE(SQLiteStatement):
         data = {}
 
         for record in records:
-            if record.isRecord():
+            if record.is_record():
                 changes = record.changes()
                 if changes:
                     sub_sql, sub_data = self.generateCommand(record, changes)
@@ -30,10 +30,10 @@ class UPDATE(SQLiteStatement):
         i18n_keys = defaultdict(list)
 
         for column in changes:
-            if column.testFlag(column.Flags.Virtual):
+            if column.test_flag(column.Flags.Virtual):
                 continue
 
-            if column.testFlag(column.Flags.I18n):
+            if column.test_flag(column.Flags.I18n):
                 for record_locale, value in record.get(column, locale='all').items():
                     value_key = '{0}_{1}'.format(column.field(), os.urandom(4).encode('hex'))
                     data[value_key] = column.dbStore('SQLite', value)
@@ -47,7 +47,7 @@ class UPDATE(SQLiteStatement):
 
 
         id_key = 'id_' + os.urandom(4).encode('hex')
-        data[id_key] = record.get(record.schema().idColumn())
+        data[id_key] = record.get(record.schema().id_column())
 
         sql = []
         if standard_values:
@@ -56,7 +56,7 @@ class UPDATE(SQLiteStatement):
                 u'SET {values}\n'
                 u'WHERE `{table}`.`{field}` = %({id})s;'
             ).format(table=record.schema().dbname(), id=id_key,
-                     values=', '.join(standard_values), field=record.schema().idColumn().field())
+                     values=', '.join(standard_values), field=record.schema().id_column().field())
             sql.append(standard_sql)
 
         if i18n_fields:

--- a/orb/core/connection_types/sql/sqlite/statements/where.py
+++ b/orb/core/connection_types/sql/sqlite/statements/where.py
@@ -53,7 +53,7 @@ class WHERE(SQLiteStatement):
 
             def convert_value(val):
                 if isinstance(val, orb.Model):
-                    return val.get(val.schema().idColumn(), inflated=False)
+                    return val.get(val.schema().id_column(), inflated=False)
                 elif isinstance(val, (tuple, list, set)):
                     return tuple(convert_value(v) for v in val)
                 else:
@@ -109,7 +109,7 @@ class WHERE(SQLiteStatement):
                 sql = u' '.join(opts)
                 data[value_key] = value
 
-                if column.testFlag(column.Flags.I18n) and column not in fields:
+                if column.test_flag(column.Flags.I18n) and column not in fields:
                     model_name = aliases.get(model) or model.schema().dbname()
                     i18n_sql = u'`{name}`.`{field}` IN (' \
                           u'    SELECT `{name}_id`' \
@@ -118,7 +118,7 @@ class WHERE(SQLiteStatement):
                           u')'
 
                     sub_sql = sql.replace('`{0}`'.format(model_name), '`{0}_i18n`'.format(model_name))
-                    sql = i18n_sql.format(name=model_name, sub_sql=sub_sql, field=model.schema().idColumn().field())
+                    sql = i18n_sql.format(name=model_name, sub_sql=sub_sql, field=model.schema().id_column().field())
 
         return sql, data
 

--- a/orb/core/database.py
+++ b/orb/core/database.py
@@ -185,7 +185,7 @@ class Database(object):
         """
         return self.__port
 
-    def setName(self, name):
+    def set_name(self, name):
         """
         Sets the database name that will be used at the lower level to manage \
         connections to various backends.
@@ -248,7 +248,7 @@ class Database(object):
         """
         self.__host = host
 
-    def setName(self, name):
+    def set_name(self, name):
         """
         Sets the database name for this instance to the given name.
 
@@ -314,10 +314,10 @@ class Database(object):
         all_models.sort(cmp=lambda x,y: cmp(x.schema(), y.schema()))
 
         tables = [model for model in all_models if issubclass(model, orb.Table) and
-                  not model.schema().testFlags(orb.Schema.Flags.Abstract) and
+                  not model.schema().test_flag(orb.Schema.Flags.Abstract) and
                   (not models or model.schema().name() in models)]
         views = [model for model in all_models if issubclass(model, orb.View) and
-                  not model.schema().testFlags(orb.Schema.Flags.Abstract) and
+                  not model.schema().test_flag(orb.Schema.Flags.Abstract) and
                   (not models or model.schema().name() in models)]
 
         # initialize the database
@@ -349,7 +349,7 @@ class Database(object):
                 # collect the missing columns and indexes
                 add = defaultdict(list)
                 for col in model.schema().columns(recurse=False).values():
-                    if col.field() not in (model_info['fields'] or []) and not col.testFlag(col.Flags.Virtual):
+                    if col.field() not in (model_info['fields'] or []) and not col.test_flag(col.Flags.Virtual):
                         add['fields'].append(col)
 
                 for index in model.schema().indexes(recurse=False).values():

--- a/orb/core/events.py
+++ b/orb/core/events.py
@@ -61,14 +61,14 @@ class ChangeEvent(RecordEvent):
     @property
     def inflated_value(self):
         if isinstance(self.column, orb.ReferenceColumn):
-            model = self.column.referenceModel()
+            model = self.column.reference_model()
             if not isinstance(self.value, model):
                 return model(self.value)
 
     @property
     def inflated_old_value(self):
         if isinstance(self.column, orb.ReferenceColumn):
-            model = self.column.referenceModel()
+            model = self.column.reference_model()
             if not isinstance(self.old, model):
                 return model(self.old)
 

--- a/orb/core/metamodel.py
+++ b/orb/core/metamodel.py
@@ -54,19 +54,19 @@ class MetaModel(type):
             def store_property(key, value):
                 if isinstance(value, orb.Column):
                     col = value
-                    col.setName(key)
+                    col.set_name(key)
                     columns[key] = col
                     return True
 
                 elif isinstance(value, orb.Index):
                     index = value
-                    index.setName(key)
+                    index.set_name(key)
                     indexes[key] = index
                     return True
 
                 elif isinstance(value, orb.Collector):
                     collector = value
-                    collector.setName(key)
+                    collector.set_name(key)
                     collectors[key] = collector
                     return True
 
@@ -82,7 +82,7 @@ class MetaModel(type):
                 if hasattr(value, '__orb__'):
                     # update the static flag when needed
                     if is_static:
-                        value.__orb__.setFlags(value.__orb__.flags() | value.__orb__.Flags.Static)
+                        value.__orb__.set_flags(value.__orb__.flags() | value.__orb__.Flags.Static)
 
                     # store the virtual object
                     if isinstance(value.__orb__, orb.Column):
@@ -128,7 +128,7 @@ class MetaModel(type):
                         attrs.setdefault('__group__', inherited_schema.group())
                         attrs.setdefault('__database__', inherited_schema.database())
                         attrs.setdefault('__namespace__', inherited_schema.namespace())
-                        attrs.setdefault('__id__', inherited_schema.idColumn().name())
+                        attrs.setdefault('__id__', inherited_schema.id_column().name())
                 else:
                     inherited_schema = None
 
@@ -140,17 +140,18 @@ class MetaModel(type):
                     database=attrs.pop('__database__', ''),
                     namespace=attrs.pop('__namespace__', ''),
                     flags=attrs.pop('__flags__', 0),
-                    idColumn = attrs.pop('__id__', 'id')
+                    id_column = attrs.pop('__id__', 'id'),
+                    system=system
                 )
 
                 if inherited_schema:
-                    schema.setInherits(inherited_schema.name())
+                    schema.set_inherits(inherited_schema.name())
 
             new_model = super(MetaModel, mcs).__new__(mcs, name, bases, attrs)
 
             # register the class to the system
             setattr(new_model, '_{0}__schema'.format(schema.name()), schema)
-            schema.setModel(new_model)
+            schema.set_model(new_model)
 
             # automatically register the model to the system
             if attrs.get('__register__', True):

--- a/orb/core/pipe.py
+++ b/orb/core/pipe.py
@@ -12,7 +12,7 @@ class Pipe(Collector):
         output['through'] = self.through()
         output['from'] = self.fromColumn().field()
         output['to'] = self.toColumn().field()
-        output['model'] = self.toColumn().referenceModel().schema().name()
+        output['model'] = self.toColumn().reference_model().schema().name()
         return output
 
     def __init__(self, through_path='', through='', from_='', to='', **options):
@@ -53,7 +53,7 @@ class Pipe(Collector):
         return target_record
 
     def collect(self, record, **context):
-        if not record.isRecord():
+        if not record.is_record():
             return orb.Collection()
         else:
             target = self.toModel()
@@ -69,14 +69,14 @@ class Pipe(Collector):
             records = target.select(**context)
             return records.bind_collector(self).bind_source_record(record)
 
-    def collectExpand(self, query, parts, **context):
+    def collect_expand(self, query, parts, **context):
         through = self.throughModel()
         toModel = self.toModel()
 
         sub_q = query.copy()
         sub_q._Query__column = '.'.join(parts[1:])
         sub_q._Query__model = toModel
-        to_records = toModel.select(columns=[toModel.schema().idColumn()], where=sub_q)
+        to_records = toModel.select(columns=[toModel.schema().id_column()], where=sub_q)
         pipe_q = orb.Query(through, self.to()).in_(to_records)
         return through.select(columns=[self.from_()], where=pipe_q)
 
@@ -122,7 +122,7 @@ class Pipe(Collector):
 
     def fromModel(self):
         col = self.fromColumn()
-        return col.referenceModel() if col else None
+        return col.reference_model() if col else None
 
     def model(self):
         return self.toModel()
@@ -157,7 +157,7 @@ class Pipe(Collector):
 
     def toModel(self):
         col = self.toColumn()
-        return col.referenceModel() if col else None
+        return col.reference_model() if col else None
 
     def through(self):
         return self.__through
@@ -169,12 +169,12 @@ class Pipe(Collector):
         except AttributeError:
             raise orb.errors.ModelNotFound(schema=self.__through)
 
-    def update_records(self, collection, source_record, record_ids, **context):
+    def update_records(self, source_record, collection, collection_ids, **context):
         orb_context = orb.Context(**context)
 
         through = self.throughModel()
         curr_ids = set(collection.ids())
-        new_ids = set(record_ids)
+        new_ids = set(collection_ids)
 
         # calculate the id shift
         remove_ids = curr_ids - new_ids

--- a/orb/core/query.py
+++ b/orb/core/query.py
@@ -5,15 +5,15 @@ agnostic queries quickly and easily.
 
 import copy
 import datetime
+import demandimport
 import projex.regex
 import projex.text
 import re
 
-from projex.enum import enum
-from projex.lazymodule import lazy_import
+from ..utils.enum import enum
 
-
-orb = lazy_import('orb')
+with demandimport.enabled():
+    import orb
 
 
 class Query(object):
@@ -180,7 +180,7 @@ class Query(object):
             try:
                 if issubclass(column, orb.Model):
                     self.__model = column
-                    self.__column = column.schema().idColumn().name()
+                    self.__column = column.schema().id_column().name()
             except StandardError:
                 if isinstance(column, orb.Column):
                     self.__model = column.schema().model()
@@ -763,7 +763,7 @@ class Query(object):
         if lookup:
             # utilize query filters to generate
             # a new filter based on this object
-            query_filter = lookup.queryFilterMethod()
+            query_filter = lookup.filtermethod()
             if callable(query_filter) and not ignoreFilter:
                 new_q = query_filter(model, self)
                 if new_q:
@@ -781,14 +781,14 @@ class Query(object):
             return self
         else:
             if isinstance(lookup, orb.Collector):
-                return orb.Query(model).in_(lookup.collectExpand(self, parts))
+                return orb.Query(model).in_(lookup.collect_expand(self, parts))
 
             elif isinstance(lookup, orb.ReferenceColumn):
-                rmodel = lookup.referenceModel()
+                rmodel = lookup.reference_model()
                 sub_q = self.copy()
                 sub_q._Query__column = '.'.join(parts[1:])
                 sub_q._Query__model = rmodel
-                records = rmodel.select(columns=[rmodel.schema().idColumn()], where=sub_q)
+                records = rmodel.select(columns=[rmodel.schema().id_column()], where=sub_q)
                 return orb.Query(model, parts[0]).in_(records)
 
             else:

--- a/orb/decorators.py
+++ b/orb/decorators.py
@@ -35,21 +35,21 @@ def virtual(cls, **options):
 
         def define_setter():
             def setter_wrapped(setter_func):
-                func.__orb__.setFlags(func.__orb__.flags() & ~cls.Flags.ReadOnly)
+                func.__orb__.set_flags(func.__orb__.flags() & ~cls.Flags.ReadOnly)
                 func.__orb__.setter()(setter_func)
                 return setter_func
             return setter_wrapped
 
         def define_query_filter():
             def shortcut_wrapped(shortcut_func):
-                func.__orb__.queryFilter(shortcut_func)
+                func.__orb__.filter(shortcut_func)
                 return shortcut_func
             return shortcut_wrapped
 
         func.__orb__ = cls(**options)
         func.__orb__.getter()(func)
         func.setter = define_setter
-        func.queryFilter = define_query_filter
+        func.filter = define_query_filter
         return func
     return wrapped
 

--- a/orb/errors.py
+++ b/orb/errors.py
@@ -1,8 +1,9 @@
 """ Defines the common errors for the database module. """
 
-from projex.lazymodule import lazy_import
+import demandimport
 
-orb = lazy_import('orb')
+with demandimport.enabled():
+    import orb
 
 # ------------------------------------------------------------------------------
 

--- a/orb/utils/enum.py
+++ b/orb/utils/enum.py
@@ -1,0 +1,96 @@
+"""
+Defines an enumeration class type used throughout the ORB project.
+
+:usage:
+
+    from orb.utils.enum import enum
+
+    Flags = enum('Required', 'Unique')
+
+    assert Flags.Required == 1
+    assert Flags.Unique == 2
+    assert (Flags.Required | Flags.Unique) == 3
+    assert Flags.from_set({'Required', 'Unique'}) == 3
+"""
+
+
+class enum(object):
+    def __init__(self, *binary_keys, **enum_values):
+        super(enum, self).__init__()
+
+        # store the base types for different values
+        binary_values = {key: 2 ** i for i, key in enumerate(binary_keys)}
+        enum_values.update(binary_values)
+
+        # set the properties
+        for name, value in enum_values.items():
+            setattr(self, name, value)
+
+        self.__enum = enum_values
+
+    def __getitem__(self, key):
+        if type(key) in (int, long):
+            for k, v in self.__enum.items():
+                if v == key:
+                    return k
+            else:
+                raise KeyError(key)
+        else:
+            return self.__enum[key]
+
+    def __json__(self):
+        return dict(self)
+
+    def __iter__(self):
+        for k, v in self.__enum.items():
+            yield k, v
+
+    def __call__(self, key):
+        """
+        Same as __getitem__.  This will cast the inputted key to its corresponding
+        value in the enumeration.  This works for both numeric and alphabetical
+        values.
+
+        :param      key | <str> || <int>
+
+        :return     <int> || <str>
+        """
+        if isinstance(key, set):
+            return self.from_set(key)
+        else:
+            return self[key]
+
+    def all(self):
+        """
+        Returns all the values joined together.
+
+        :return     <int>
+        """
+        out = 0
+        for key, value in self.__enum.items():
+            out |= value
+        return out
+
+    def from_set(self, values):
+        """
+        Generates a flag value based on the given set of values.
+
+        :param values: <set>
+
+        :return: <int>
+        """
+        value = 0
+        for flag in values:
+            value |= self(flag)
+        return value
+
+    def to_set(self, flags):
+        """
+        Generates a flag value based on the given set of values.
+
+        :param values: <set>
+
+        :return: <int>
+        """
+        return {key for key, value in self.__enum.items() if value & flags}
+

--- a/tests/functional/mysql/test_my_statements.py
+++ b/tests/functional/mysql/test_my_statements.py
@@ -63,7 +63,7 @@ def test_my_statement_alter_invalid(orb, my_sql):
 
 def test_my_statement_create_index(orb, GroupUser, my_sql):
     index = orb.Index(name='byGroupAndUser', columns=[orb.ReferenceColumn(name='group'), orb.ReferenceColumn('user')])
-    index.setSchema(GroupUser.schema())
+    index.set_schema(GroupUser.schema())
     st = my_sql.statement('CREATE INDEX')
     assert st is not None
 

--- a/tests/functional/postgres/conftest.py
+++ b/tests/functional/postgres/conftest.py
@@ -7,7 +7,7 @@ def pg_db(request):
     import orb
 
     db = orb.Database('Postgres')
-    db.setName('orb_testing')
+    db.set_name('orb_testing')
     db.setHost('localhost')
     db.setUsername(getpass.getuser())
     db.setPassword('')

--- a/tests/functional/postgres/test_02_pg_statements.py
+++ b/tests/functional/postgres/test_02_pg_statements.py
@@ -78,7 +78,7 @@ def test_pg_statement_create_index(orb, GroupUser, pg_sql):
             orb.ReferenceColumn(name='user')
         ]
     )
-    index.setSchema(GroupUser.schema())
+    index.set_schema(GroupUser.schema())
     st = pg_sql.statement('CREATE INDEX')
     assert st is not None
 

--- a/tests/functional/sqlite/conftest.py
+++ b/tests/functional/sqlite/conftest.py
@@ -5,7 +5,7 @@ def lite_db():
     import orb
 
     db = orb.Database('SQLite')
-    db.setName('orb_testing')
+    db.set_name('orb_testing')
     db.activate()
 
     def fin():

--- a/tests/functional/sqlite/test_lite_statements.py
+++ b/tests/functional/sqlite/test_lite_statements.py
@@ -49,7 +49,7 @@ def test_lite_statement_create_index(orb, GroupUser, lite_sql):
             orb.ReferenceColumn(name='user')
         ]
     )
-    index.setSchema(GroupUser.schema())
+    index.set_schema(GroupUser.schema())
     st = lite_sql.statement('CREATE INDEX')
     assert st is not None
 

--- a/tests/unit/core/test_collection.py
+++ b/tests/unit/core/test_collection.py
@@ -151,22 +151,22 @@ def test_collection_serialization_of_column_data(mock_user_data, MockUser, asser
     from orb.core.collection import Collection
 
     collection = Collection(model=MockUser, returning='data', columns='username')
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
     data = collection.__json__()
     assert data[0] == {'username': 'jdoe'}
 
     collection = Collection(model=MockUser, returning='values', columns='username')
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
     data = collection.__json__()
     assert data[0] == 'jdoe'
 
     collection = Collection(model=MockUser, returning='values', columns='username,last_name')
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
     data = collection.__json__()
     assert data[0] == ('jdoe', 'Doe')
 
     collection = Collection(model=MockUser, returning='data')
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
     data = collection.__json__()
     assert_dict_equals(mock_user_data, data[0])
 
@@ -175,7 +175,7 @@ def test_collection_returning_data(mock_user_data, MockUser):
     from orb.core.collection import Collection
 
     collection = Collection(model=MockUser, returning='data', columns='username')
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
     data = collection.records()
     assert data[0] == {'username': 'jdoe'}
 
@@ -304,7 +304,7 @@ def test_preloading_collection_data(mock_user_collection,
                                     MockUser,
                                     assert_dict_equals):
     collection = mock_user_collection(0)
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
 
     assert len(collection) == 1
     assert isinstance(collection[0], MockUser)
@@ -387,7 +387,7 @@ def test_copy_collection_with_collector_and_record(mock_user_collection,
 def test_copy_collection_with_preloaded_data(mock_user_collection,
                                              mock_user_data):
     collection = mock_user_collection(0)
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
     coll_copy = collection.copy()
     assert len(coll_copy) == 1
 
@@ -403,7 +403,7 @@ def test_collection_with_preloaded_count():
     from orb.core.collection import Collection
 
     collection = Collection()
-    collection.add_preloaded_data({'count': 3})
+    collection._add_preloaded_data({'count': 3})
 
     assert len(collection) == 3
 
@@ -412,7 +412,7 @@ def test_collection_count_with_preloaded_records(mock_user_data):
     from orb.core.collection import Collection
 
     collection = Collection()
-    collection.add_preloaded_data({'records': [mock_user_data]})
+    collection._add_preloaded_data({'records': [mock_user_data]})
 
     assert len(collection) == 1
 
@@ -499,7 +499,7 @@ def test_retrieve_first_record_from_preloaded_cache(mock_user_data, MockUser):
     from orb.core.collection import Collection
 
     collection = Collection(model=MockUser)
-    collection.add_preloaded_data({'first': mock_user_data})
+    collection._add_preloaded_data({'first': mock_user_data})
 
     record = collection.first()
     assert record is not None
@@ -662,7 +662,7 @@ def test_collection_preloaded_with_preloaded_ids():
     from orb.core.collection import Collection
 
     collection = Collection()
-    collection.add_preloaded_data({'ids': [1]})
+    collection._add_preloaded_data({'ids': [1]})
 
     assert collection.ids() == [1]
 
@@ -737,7 +737,7 @@ def test_retrieve_last_record_from_preloaded_cache(mock_user_data, MockUser):
     from orb.core.collection import Collection
 
     collection = Collection(model=MockUser)
-    collection.add_preloaded_data({'last': mock_user_data})
+    collection._add_preloaded_data({'last': mock_user_data})
     assert collection.last().get('username') == mock_user_data['username']
 
 
@@ -1035,13 +1035,13 @@ def test_update_collection_with_record_creation_from_collector(mock_db, MockUser
             return user
 
         def update_records(self,
-                           collection,
                            source_record,
-                           new_ids,
+                           collection,
+                           collection_ids,
                            **context):
-            assert collection == self.collection
             assert source_record == self.source
-            assert new_ids == (100,)
+            assert collection == self.collection
+            assert collection_ids == (100,)
             self.updated = True
 
     a = MockUser()
@@ -1094,7 +1094,7 @@ def test_expand_reference_values(mock_db, MockUser, MockGroup):
 
     db = mock_db(responses={'select': select_data})
     collection = Collection(model=MockUser, db=db)
-    collection.add_preloaded_data({'id': 1, 'group_id': 1})
+    collection._add_preloaded_data({'id': 1, 'group_id': 1})
 
     groups = collection.values('group')
     assert len(groups) == 1

--- a/tests/unit/core/test_collector.py
+++ b/tests/unit/core/test_collector.py
@@ -1,0 +1,189 @@
+import pytest
+
+def test_basic_collector():
+    from orb.core.collector import Collector
+
+    collector = Collector(name='testing', flags={'Unique'})
+
+    assert collector.__name__ == 'testing'
+    assert collector.name() == 'testing'
+    assert collector(None).is_null()
+    assert collector.test_flag(Collector.Flags.Unique) is True
+    assert collector.test_flag(Collector.Flags.AutoExpand) is False
+
+
+def test_abstract_collector_methods():
+    from orb.core.collector import Collector
+
+    collector = Collector()
+    with pytest.raises(NotImplementedError):
+        collector._collect(None)
+    with pytest.raises(NotImplementedError):
+        collector.add_record(None, None)
+    with pytest.raises(NotImplementedError):
+        collector.collect_expand(None, [])
+    with pytest.raises(NotImplementedError):
+        collector.create_record(None, {})
+    with pytest.raises(NotImplementedError):
+        collector.delete_records([])
+    with pytest.raises(NotImplementedError):
+        collector.remove_record(None, None)
+    with pytest.raises(NotImplementedError):
+        collector.update_records([], None, [])
+
+
+def test_collector_serialization(MockUser):
+    from orb.core.collector import Collector
+
+    a = Collector(name='testing', flags={'Unique'})
+    b = Collector(name='testing', model=MockUser, flags=1)
+    c = Collector(name='testing', model='User')
+
+    assert a.__json__() == {'name': 'testing',
+                            'model': None,
+                            'flags': {'Unique': True}}
+    assert b.__json__() == {'name': 'testing',
+                            'model': 'MockUser',
+                            'flags': {'Unique': True}}
+
+    assert c.__json__() == {'name': 'testing',
+                            'model': None,
+                            'flags': {}}
+
+
+def test_collector_callable_not_implemented(MockUser):
+    from orb.core.collector import Collector
+
+    collector = Collector()
+
+    source_record = MockUser({'id': 1})
+    source_record.mark_loaded('id')
+
+    assert source_record.is_record()
+
+    with pytest.raises(NotImplementedError):
+        collector(source_record)
+
+
+def test_collector_filter_wrapper():
+    from orb.core.query import Query as Q
+    from orb.core.collector import Collector
+
+    checks = {}
+
+    def build_filter(q, **context):
+        checks['filtered'] = True
+        assert isinstance(q, Q)
+        return q
+
+    a = Collector(filter=build_filter)
+    b = Collector()
+    b.filter(build_filter)
+    c = Collector()
+    c.filter()(build_filter)
+
+    assert a.filtermethod() == build_filter
+    assert b.filtermethod() == build_filter
+    assert c.filtermethod() == build_filter
+
+    assert a.filtermethod()(Q('collector') == True)
+    assert checks['filtered'] is True
+
+
+def test_collector_getter_wrapper():
+    from orb.core.collection import Collection
+    from orb.core.collector import Collector
+
+    checks = {}
+
+    def get_records(source_record, **context):
+        checks['fetched'] = True
+        return Collection()
+
+    a = Collector(getter=get_records)
+    b = Collector()
+    b.getter(get_records)
+    c = Collector()
+    c.getter()(get_records)
+
+    assert a.gettermethod() == get_records
+    assert b.gettermethod() == get_records
+    assert c.gettermethod() == get_records
+
+    assert checks.get('fetched') is None
+    assert a.gettermethod()(None).is_null()
+    assert checks.pop('fetched') is True
+
+    assert a(None).is_null()
+    assert checks.pop('fetched') is True
+
+
+def test_collector_setter_wrapper():
+    from orb.core.collection import Collection
+    from orb.core.collector import Collector
+
+    checks = {}
+
+    def set_records(source_record, records, **context):
+        checks['set'] = True
+        return Collection()
+
+    a = Collector(setter=set_records)
+    b = Collector()
+    b.setter(set_records)
+    c = Collector()
+    c.setter()(set_records)
+
+    assert a.settermethod() == set_records
+    assert b.settermethod() == set_records
+    assert c.settermethod() == set_records
+
+    assert checks.get('set') is None
+    assert a.settermethod()(None, []).is_null()
+    assert checks.pop('set') is True
+
+def test_collector_collection_method(mock_db, MockUser):
+    from orb.core.context import Context
+    from orb.core.collection import Collection
+    from orb.core.collector import Collector
+
+    class MockCollector(Collector):
+        def __init__(self, response, **kw):
+            super(MockCollector, self).__init__(**kw)
+
+            self.response = response
+
+        def _collect(self, source_record, **records):
+            return self.response
+
+    without_preload = Collection([MockUser({'username': 'jdoe'})])
+    with_preload = Collection(model=MockUser)
+
+    a = MockCollector(without_preload)
+    b = MockCollector(with_preload, name='testing')
+    c = MockCollector(without_preload, name='testing', flags={'Unique'})
+    d = MockCollector([{'username': 'jdoe'}])
+    e = MockCollector(MockUser({'username': 'jdoe'}))
+
+    # create a source record for the collection
+    source = MockUser({'id': 1})
+    source.mark_loaded('id')
+    source._add_preloaded_data({'testing': [{'username': 'jdoe'}]})
+
+    a_records = a(source)
+    b_records = b(source)
+    c_records = c(source)
+    d_records = d(source)
+    e_records = e(source)
+
+    assert isinstance(a_records, Collection)
+    assert isinstance(b_records, Collection)
+    assert isinstance(c_records, MockUser)
+    assert isinstance(d_records, list)
+    assert isinstance(e_records, MockUser)
+
+    assert a_records.at(0).get('username') == 'jdoe'
+    assert b_records.at(0).get('username') == 'jdoe'
+    assert c_records.get('username') == 'jdoe'
+    assert d_records[0].get('username') == 'jdoe'
+    assert e_records.get('username') == 'jdoe'

--- a/tests/unit/core/test_schema.py
+++ b/tests/unit/core/test_schema.py
@@ -1,0 +1,342 @@
+import pytest
+
+
+@pytest.fixture()
+def UserSchema():
+    from orb.core.schema import Schema
+    from orb.core.system import System
+    from orb.core.column import Column
+    from orb.core.collector import Collector
+    from orb.core.index import Index
+
+    system = System()
+
+    schema = Schema(
+        name='User',
+        system=system,
+        columns=[
+            Column(name='id'),
+            Column(name='username'),
+            Column(name='permits', flags={'Private'})
+        ],
+        indexes=[
+            Index(name='by_username'),
+            Index(name='by_permits', flags={'Private'})
+        ],
+        collectors=[
+            Collector(name='groups'),
+            Collector(name='permissions', flags={'Private'})
+        ]
+    )
+
+    system.register(schema)
+
+    return schema
+
+
+def test_basic_schema_creation():
+    import orb
+    from orb.core.schema import Schema
+
+    schema = Schema()
+    assert schema.name() == ''
+    assert schema.display() == ''
+    assert schema.group() == ''
+    assert schema.inherits() == ''
+    assert schema.flags() == 0
+    assert schema.alias() == ''
+    assert schema.dbname() == ''
+    assert schema.namespace() == ''
+    assert schema.database() == ''
+    assert schema.columns() == {}
+    assert schema.indexes() == {}
+    assert schema.collectors() == {}
+    assert schema.system() == orb.system
+
+    with pytest.raises(orb.errors.ColumnNotFound):
+        assert schema.id_column() is None
+
+
+def test_basic_schema_creation_with_properties():
+    from orb.core.schema import Schema
+
+    schema = Schema(
+        name='MockUser',
+        group='auth',
+        inherits='MockAccount',
+    )
+
+    assert schema.name() == 'MockUser'
+    assert schema.display() == 'Mock User'
+    assert schema.inherits() == 'MockAccount'
+    assert schema.group() == 'auth'
+    assert schema.alias() == 'mock_users'
+    assert schema.dbname() == 'mock_users'
+
+
+def test_basic_schema_creation_with_overrides():
+    from orb.core.schema import Schema
+
+    schema = Schema(
+        name='MockUser',
+        alias='mock_user',
+        dbname='users',
+        display='User'
+    )
+
+    assert schema.name() == 'MockUser'
+    assert schema.display() == 'User'
+    assert schema.alias() == 'mock_user'
+    assert schema.dbname() == 'users'
+
+
+def test_schema_ancestry():
+    from orb.core.system import System
+    from orb.core.schema import Schema
+
+    system = System()
+
+    a = Schema(name='Fruit', system=system)
+    b = Schema(name='Apple', inherits='Fruit', system=system)
+    c = Schema(name='GrannySmith', inherits='Apple', system=system)
+
+    system.register(a)
+    system.register(b)
+    system.register(c)
+
+    a_inherits = list(a.ancestry())
+    b_inherits = list(b.ancestry())
+    c_inherits = list(c.ancestry())
+
+    assert a_inherits == []
+    assert b_inherits == [a]
+    assert c_inherits == [b, a]
+
+
+def test_schema_ordering():
+    from orb.core.system import System
+    from orb.core.schema import Schema
+
+    system = System()
+
+    a = Schema(name='Fruit', system=system)
+    b = Schema(name='Apple', inherits='Fruit', system=system)
+    c = Schema(name='GrannySmith', inherits='Apple', system=system)
+    d = Schema(name='Vegetable', system=system)
+    e = Schema(name='Broccoli', inherits='Vegetable', system=system)
+
+    system.register(a)
+    system.register(b)
+    system.register(c)
+    system.register(d)
+    system.register(e)
+
+    schemas = [a, b, c, d, e, 1]
+    schemas.sort()
+
+    assert schemas == [a, d, b, e, c, 1]
+
+
+def test_schema_serialization(UserSchema):
+    data = UserSchema.__json__()
+
+    assert data['model'] == 'User'
+    assert data['id_column'] == 'id'
+    assert data['dbname'] == 'users'
+    assert data['display'] == 'User'
+    assert data['inherits'] == ''
+    assert data['flags'] == {}
+    assert len(data['columns']) == 2
+    assert len(data['indexes']) == 1
+    assert len(data['collectors']) == 1
+
+
+def test_schema_with_inheritance(UserSchema):
+    import orb
+    from orb.core.schema import Schema
+    from orb.core.column import Column
+
+    schema = Schema(
+        name='Employee',
+        inherits='User',
+        columns=[
+            Column(name='role')
+        ],
+        system=UserSchema.system()
+    )
+
+    UserSchema.system().register(schema)
+
+    assert schema.column('role').schema() == schema
+    assert schema.column('username').schema() == UserSchema
+    assert schema.index('by_username').schema() == UserSchema
+    assert schema.collector('groups').schema() == UserSchema
+
+    with pytest.raises(orb.errors.ColumnNotFound):
+        assert not schema.column('role_name')
+
+    assert schema.column('role_name', raise_=False) is None
+
+
+def test_schema_column_association(UserSchema):
+    from orb.core.column import Column
+
+    a = Column()
+    b = Column()
+
+    assert a != b
+    assert a not in [b]
+
+    assert UserSchema.has_column('username')
+    assert UserSchema.has_column(UserSchema.column('username'))
+    assert UserSchema.has_column(Column()) is False
+
+
+def test_schema_with_translation_columns(UserSchema):
+    from orb.core.schema import Schema
+    from orb.core.column import Column
+
+    schema = Schema(
+        name='testing',
+        columns=[
+            Column(name='title', flags={'I18n'})
+        ]
+    )
+
+    assert UserSchema.has_translations() is False
+    assert schema.has_translations() is True
+
+
+def test_schema_with_namespace():
+    from orb.core.schema import Schema
+
+    a = Schema(namespace='groups')
+    b = Schema()
+
+    assert a.namespace() == 'groups'
+    assert b.namespace() == ''
+    assert a.namespace(namespace='testing') == 'groups'
+    assert b.namespace(namespace='testing') == 'testing'
+    assert a.namespace(namespace='testing', force_namespace=True) == 'testing'
+    assert b.namespace(namespace='testing', force_namespace=True) == 'testing'
+
+
+def test_schema_registration():
+    from orb.core.schema import Schema
+    from orb.core.column import Column
+    from orb.core.collector import Collector
+    from orb.core.index import Index
+
+    a = Schema()
+    a.register(Column(name='id'))
+    a.register(Collector(name='groups'))
+    a.register(Index(name='by_group'))
+
+    def testing():
+        pass
+
+    setattr(testing, '__orb__', Column(name='testing'))
+    a.register(testing)
+
+    with pytest.raises(RuntimeError):
+        a.register(Schema(name='schema'))
+
+    assert a.column('id') is not None
+    assert a.collector('groups') is not None
+    assert a.index('by_group') is not None
+    assert a.column('testing') is not None
+
+
+def test_schema_flags():
+    from orb.core.schema import Schema
+
+    schema = Schema(flags={'Private'})
+    assert schema.test_flag(Schema.Flags.Private)
+    assert schema.test_flag(Schema.Flags.Abstract) is False
+
+
+def test_schema_does_not_serialize_private_relations():
+    import orb
+    from orb.core.system import System
+
+    system = System()
+
+    class User(orb.Table):
+        __system__ = system
+
+        id = orb.IdColumn()
+        group = orb.ReferenceColumn('Group', field='group')
+
+        groups = orb.Collector(model='Group')
+
+    class Group(orb.Table):
+        __system__ = system
+        __flags__ = {'Private'}
+
+        id = orb.IdColumn()
+        name = orb.StringColumn()
+
+    jdata = User.schema().__json__()
+
+    assert 'group' not in jdata['columns']
+    assert 'groups' not in jdata['collectors']
+
+
+def test_schema_registration_of_index_creates_method():
+    import orb
+    from orb.core.system import System
+    from orb.core.index import Index
+
+    system = System()
+
+    class User(orb.Table):
+        __system__ = system
+
+    User.schema().register(Index(name='by_username'))
+    assert User.by_username is not None
+
+
+def test_access_of_column_via_subpath():
+    import orb
+
+    system = orb.System()
+
+    class User(orb.Table):
+        __system__ = system
+
+        group = orb.ReferenceColumn('Group')
+
+    class Group(orb.Table):
+        __system__ = system
+
+        role = orb.ReferenceColumn('Role')
+
+    class Role(orb.Table):
+        __system__ = system
+
+        name = orb.StringColumn()
+
+    assert system.model('User') == User
+    assert system.model('Group') == Group
+    assert system.model('Role') == Role
+    assert User.schema().column('group').schema().system() == system
+    assert User.schema().column('group').reference_model() == Group
+    assert User.schema().column('group.role.name') == Role.schema().column('name')
+
+    with pytest.raises(orb.errors.ColumnNotFound):
+        assert not User.schema().column('group.role.person')
+
+    with pytest.raises(orb.errors.ColumnNotFound):
+        assert not User.schema().column('group.missing')
+
+    assert User.schema().column('group.role.missing', raise_=False) is None
+    assert User.schema().column('group.code', raise_=False) is None
+    assert User.schema().column('group.code', raise_=False) is None
+    assert User.schema().column('group.role.missing', raise_=False) is None
+    assert User.schema().column('group.name.missing', raise_=False) is None
+
+    with pytest.raises(orb.errors.ColumnNotFound):
+        assert not User.schema().column('group.role.missing')
+
+    with pytest.raises(orb.errors.ColumnNotFound):
+        assert not User.schema().column('group.name.missing_also')

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -15,7 +15,7 @@ def test_create_virtual_string():
     assert my_method.__orb__.name() == 'my_method'
     assert my_method.__orb__.gettermethod() == my_method
     assert my_method.__orb__.settermethod() is None
-    assert my_method.__orb__.queryFilterMethod() is None
+    assert my_method.__orb__.filtermethod() is None
     assert my_method.__orb__.flags() == (orb.Column.Flags.Virtual | orb.Column.Flags.ReadOnly)
 
 
@@ -71,11 +71,11 @@ def test_create_virtual_string_with_a_query_filter():
     def param():
         pass
 
-    @param.queryFilter()
+    @param.filter()
     def param_filter():
         pass
 
-    assert param.__orb__.queryFilterMethod() == param_filter
+    assert param.__orb__.filtermethod() == param_filter
 
 
 def test_create_virtual_string_with_a_name_override():
@@ -108,7 +108,7 @@ def test_create_virtual_collector():
     def set_properties(values):
         pass
 
-    @properties.queryFilter()
+    @properties.filter()
     def properties_filter(query):
         pass
 
@@ -116,7 +116,7 @@ def test_create_virtual_collector():
     assert isinstance(properties.__orb__, orb.Collector)
     assert properties.__orb__.gettermethod() == properties
     assert properties.__orb__.settermethod() == set_properties
-    assert properties.__orb__.queryFilterMethod() == properties_filter
+    assert properties.__orb__.filtermethod() == properties_filter
 
     with pytest.raises(orb.errors.ModelNotFound):
         properties.__orb__.model()
@@ -135,7 +135,7 @@ def test_create_virtual_reverse_lookup():
     def set_properties(values):
         pass
 
-    @properties.queryFilter()
+    @properties.filter()
     def properties_filter(query):
         pass
 
@@ -144,7 +144,7 @@ def test_create_virtual_reverse_lookup():
     assert isinstance(properties.__orb__, orb.ReverseLookup)
     assert properties.__orb__.gettermethod() == properties
     assert properties.__orb__.settermethod() == set_properties
-    assert properties.__orb__.queryFilterMethod() == properties_filter
+    assert properties.__orb__.filtermethod() == properties_filter
 
     with pytest.raises(orb.errors.ModelNotFound):
         properties.__orb__.model()
@@ -163,7 +163,7 @@ def test_create_virtual_pipe():
     def set_properties(values):
         pass
 
-    @properties.queryFilter()
+    @properties.filter()
     def properties_filter(query):
         pass
 
@@ -172,7 +172,7 @@ def test_create_virtual_pipe():
     assert isinstance(properties.__orb__, orb.Pipe)
     assert properties.__orb__.gettermethod() == properties
     assert properties.__orb__.settermethod() == set_properties
-    assert properties.__orb__.queryFilterMethod() == properties_filter
+    assert properties.__orb__.filtermethod() == properties_filter
 
     with pytest.raises(orb.errors.ModelNotFound):
         properties.__orb__.model()

--- a/tests/unit/utils/test_enum.py
+++ b/tests/unit/utils/test_enum.py
@@ -68,6 +68,3 @@ def test_enum_fetch_all_values(mock_binary_enum):
     all = mock_binary_enum.all()
     assert all == 7
 
-
-def test_enum_iterate_over_items(mock_binary_enum):
-    assert len(mock_binary_enum.items()) == len(mock_binary_enum)

--- a/tests/unit/utils/test_enum.py
+++ b/tests/unit/utils/test_enum.py
@@ -1,0 +1,69 @@
+import pytest
+
+@pytest.fixture()
+def mock_binary_enum():
+    from orb.utils.enum import enum
+
+    return enum('Required', 'Unique', 'Expanded')
+
+
+def test_enum_definition(mock_binary_enum):
+    assert mock_binary_enum.Required == 1
+    assert mock_binary_enum.Unique == 2
+    assert mock_binary_enum.Expanded == 4
+
+
+def test_enum_get_by_key(mock_binary_enum):
+    assert mock_binary_enum['Required'] == 1
+    assert mock_binary_enum['Unique'] == 2
+
+    with pytest.raises(KeyError):
+        assert mock_binary_enum['Test']
+
+
+def test_enum_get_by_value(mock_binary_enum):
+    assert mock_binary_enum[1] == 'Required'
+    assert mock_binary_enum[2] == 'Unique'
+    assert mock_binary_enum[4] == 'Expanded'
+
+    with pytest.raises(KeyError):
+        assert mock_binary_enum[3]
+
+
+def test_enum_get_by_call(mock_binary_enum):
+    assert mock_binary_enum(1) == 'Required'
+    assert mock_binary_enum('Required') == 1
+    assert mock_binary_enum({'Required', 'Unique'}) == 3
+
+    with pytest.raises(KeyError):
+        assert mock_binary_enum('Test')
+
+
+def test_enum_get_by_set(mock_binary_enum):
+    values = mock_binary_enum.from_set({'Required', 'Unique'})
+    assert values == 3
+
+    with pytest.raises(KeyError):
+        assert mock_binary_enum.from_set({'Required', 'Unique', 'Test'})
+
+
+def test_enum_json(mock_binary_enum):
+    assert mock_binary_enum.__json__() == {'Required': 1, 'Unique': 2, 'Expanded': 4}
+
+
+def test_enum_value_as_set(mock_binary_enum):
+    assert mock_binary_enum.to_set(3) == {'Required', 'Unique'}
+
+
+def test_custom_enum():
+    from orb.utils.enum import enum
+
+    custom = enum(A=1, B=2, C=3)
+    assert custom.A == 1
+    assert custom.B == 2
+    assert custom.C == 3
+
+
+def test_enum_fetch_all_values(mock_binary_enum):
+    all = mock_binary_enum.all()
+    assert all == 7

--- a/tests/unit/utils/test_enum.py
+++ b/tests/unit/utils/test_enum.py
@@ -67,3 +67,7 @@ def test_custom_enum():
 def test_enum_fetch_all_values(mock_binary_enum):
     all = mock_binary_enum.all()
     assert all == 7
+
+
+def test_enum_iterate_over_items(mock_binary_enum):
+    assert len(mock_binary_enum.items()) == len(mock_binary_enum)


### PR DESCRIPTION
…n, hasColumn => has_column, setName => set_name, setSchema => set_schema, referenceModel => reference_model

* renaming the `queryFilter` to just `filter` to fit better with the `getter` and `setter` naming
* Collector.delete_records raises NotImplementedError by default now (proper abstraction)
* 100% code coverage on collector.py
* 100% code coverage on schema.py
* 100% code coverage on enum.py
* replacement of projex.enum for orb.utils.enum